### PR TITLE
CPU controlled notes fix

### DIFF
--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -4254,7 +4254,7 @@ class PlayState extends MusicBeatState
 				if(note.isSustainNote && !note.animation.curAnim.name.endsWith('end')) {
 					time += 0.15;
 				}
-				StrumPlayAnim(false, Std.int(Math.abs(note.noteData)) % 4, time);
+				StrumPlayAnim(false, Std.int(Math.abs(note.noteData)) % Main.ammo[mania], time);
 			} else {
 				playerStrums.forEach(function(spr:StrumNote)
 				{


### PR DESCRIPTION
When you enable botplay on a 6/7/9k song it only plays the note anim on 4 notes instead of all, this fixes it.